### PR TITLE
Slot Rename

### DIFF
--- a/default-json-configs/barbarian.json
+++ b/default-json-configs/barbarian.json
@@ -2,7 +2,7 @@
   "path": "Berserker",
   "rage": {
     "available": 2,
-    "slot": 2,
+    "maximum": 2,
     "damage": 2
   },
   "primal-knowledge": [

--- a/default-json-configs/bard.json
+++ b/default-json-configs/bard.json
@@ -1,7 +1,7 @@
 {
   "bardic-inspiration": {
     "available": 4,
-    "slot": 4
+    "maximum": 4
   },
   "college":  "Bardic School of Creation",
   "expertise": [

--- a/default-json-configs/character.json
+++ b/default-json-configs/character.json
@@ -161,47 +161,47 @@
     {
       "level": 1,
       "available": 0,
-      "slot": 0
+      "maximum": 0
     },
     {
       "level": 2,
       "available": 0,
-      "slot": 0
+      "maximum": 0
     },
     {
       "level": 3,
       "available": 0,
-      "slot": 0
+      "maximum": 0
     },
     {
       "level": 4,
       "available": 0,
-      "slot": 0
+      "maximum": 0
     },
     {
       "level": 5,
       "available": 0,
-      "slot": 0
+      "maximum": 0
     },
     {
       "level": 6,
       "available": 0,
-      "slot": 0
+      "maximum": 0
     },
     {
       "level": 7,
       "available": 0,
-      "slot": 0
+      "maximum": 0
     },
     {
       "level": 8,
       "available": 0,
-      "slot": 0
+      "maximum": 0
     },
     {
       "level": 9,
       "available": 0,
-      "slot": 0
+      "maximum": 0
     }
   ],
   "weapons": [

--- a/models/character.go
+++ b/models/character.go
@@ -424,7 +424,7 @@ func (c *Character) BuildSpells() []string {
 
 	for _, spellSlot := range c.SpellSlots {
 		fullCircle := strings.Repeat("● ", spellSlot.Available)
-		hollowCircle := strings.Repeat("○ ", (spellSlot.Slot - spellSlot.Available))
+		hollowCircle := strings.Repeat("○ ", (spellSlot.Maximum - spellSlot.Available))
 		slotRow := fmt.Sprintf("	- Level %d: %s%s\n", spellSlot.Level, fullCircle, hollowCircle)
 		s = append(s, slotRow)
 	}
@@ -673,7 +673,7 @@ func (c *Character) UseSpellSlot(level int) {
 func (c *Character) RecoverSpellSlots(level int) {
 	for i := range c.SpellSlots {
 		if c.SpellSlots[i].Level == level {
-			c.SpellSlots[i].Available = c.SpellSlots[i].Slot
+			c.SpellSlots[i].Available = c.SpellSlots[i].Maximum
 		}
 	}
 }
@@ -682,7 +682,7 @@ func (c *Character) Recover() {
 	c.HPCurrent = c.HPMax
 
 	for i := range c.SpellSlots {
-		c.SpellSlots[i].Available = c.SpellSlots[i].Slot
+		c.SpellSlots[i].Available = c.SpellSlots[i].Maximum
 	}
 
 	if c.Class != nil {

--- a/models/character_test.go
+++ b/models/character_test.go
@@ -334,16 +334,16 @@ func TestCharacterRecover(t *testing.T) {
 				HPMax:     16,
 				ClassName: "character",
 				SpellSlots: []types.SpellSlot{
-					{Level: 1, Slot: 4, Available: 1},
-					{Level: 2, Slot: 2, Available: 0},
+					{Level: 1, Maximum: 4, Available: 1},
+					{Level: 2, Maximum: 2, Available: 0},
 				},
 			},
 			expected: Character{
 				HPCurrent: 16,
 				HPMax:     16,
 				SpellSlots: []types.SpellSlot{
-					{Level: 1, Slot: 4, Available: 4},
-					{Level: 2, Slot: 2, Available: 2},
+					{Level: 1, Maximum: 4, Available: 4},
+					{Level: 2, Maximum: 2, Available: 2},
 				},
 			},
 		},
@@ -353,16 +353,16 @@ func TestCharacterRecover(t *testing.T) {
 				HPCurrent: 0,
 				HPMax:     16,
 				SpellSlots: []types.SpellSlot{
-					{Level: 1, Slot: 4, Available: 1},
-					{Level: 2, Slot: 2, Available: 0},
+					{Level: 1, Maximum: 4, Available: 1},
+					{Level: 2, Maximum: 2, Available: 0},
 				},
 			},
 			expected: Character{
 				HPCurrent: 16,
 				HPMax:     16,
 				SpellSlots: []types.SpellSlot{
-					{Level: 1, Slot: 4, Available: 4},
-					{Level: 2, Slot: 2, Available: 2},
+					{Level: 1, Maximum: 4, Available: 4},
+					{Level: 2, Maximum: 2, Available: 2},
 				},
 			},
 		},
@@ -413,13 +413,13 @@ func TestCharacterUseSpellSlot(t *testing.T) {
 			level: 1,
 			character: &Character{
 				SpellSlots: []types.SpellSlot{
-					{Level: 1, Slot: 6, Available: 6},
-					{Level: 2, Slot: 3, Available: 3},
+					{Level: 1, Maximum: 6, Available: 6},
+					{Level: 2, Maximum: 3, Available: 3},
 				},
 			},
 			expected: []types.SpellSlot{
-				{Level: 1, Slot: 6, Available: 5},
-				{Level: 2, Slot: 3, Available: 3},
+				{Level: 1, Maximum: 6, Available: 5},
+				{Level: 2, Maximum: 3, Available: 3},
 			},
 		},
 		{
@@ -427,13 +427,13 @@ func TestCharacterUseSpellSlot(t *testing.T) {
 			level: 1,
 			character: &Character{
 				SpellSlots: []types.SpellSlot{
-					{Level: 1, Slot: 6, Available: 0},
-					{Level: 2, Slot: 3, Available: 3},
+					{Level: 1, Maximum: 6, Available: 0},
+					{Level: 2, Maximum: 3, Available: 3},
 				},
 			},
 			expected: []types.SpellSlot{
-				{Level: 1, Slot: 6, Available: 0},
-				{Level: 2, Slot: 3, Available: 3},
+				{Level: 1, Maximum: 6, Available: 0},
+				{Level: 2, Maximum: 3, Available: 3},
 			},
 		},
 	}
@@ -465,13 +465,13 @@ func TestCharacterRecoverSpellSlots(t *testing.T) {
 			level: 1,
 			character: &Character{
 				SpellSlots: []types.SpellSlot{
-					{Level: 1, Slot: 6, Available: 3},
-					{Level: 2, Slot: 3, Available: 3},
+					{Level: 1, Maximum: 6, Available: 3},
+					{Level: 2, Maximum: 3, Available: 3},
 				},
 			},
 			expected: []types.SpellSlot{
-				{Level: 1, Slot: 6, Available: 6},
-				{Level: 2, Slot: 3, Available: 3},
+				{Level: 1, Maximum: 6, Available: 6},
+				{Level: 2, Maximum: 3, Available: 3},
 			},
 		},
 	}

--- a/models/class/barbarian.go
+++ b/models/class/barbarian.go
@@ -18,7 +18,7 @@ type Barbarian struct {
 
 type Rage struct {
 	Available int `json:"available"`
-	Slot      int `json:"token"`
+	Maximum   int `json:"maximum"`
 	Damage    int `json:"damage"`
 }
 
@@ -109,8 +109,8 @@ func (b *Barbarian) executeUnarmoredDefense(c *models.Character) {
 func (b *Barbarian) PrintClassDetails(c *models.Character) []string {
 	s := c.BuildClassDetailsHeader()
 
-	if b.Rage.Available != 0 && b.Rage.Slot != 0 {
-		rageSlots := c.GetSlots(b.Rage.Available, b.Rage.Slot)
+	if b.Rage.Available != 0 && b.Rage.Maximum != 0 {
+		rageSlots := c.GetSlots(b.Rage.Available, b.Rage.Maximum)
 		rageLine := fmt.Sprintf("**Rage**: %s - Damage: +%d\n\n", rageSlots, b.Rage.Damage)
 		s = append(s, rageLine)
 	}
@@ -170,7 +170,7 @@ func (b *Barbarian) RecoverClassTokens(tokenName string, quantity int) {
 	b.Rage.Available += quantity
 
 	// if no quantity is provided, or the new value exceeds the max we will perform a full recover
-	if quantity == 0 || b.Rage.Available > b.Rage.Slot {
-		b.Rage.Available = b.Rage.Slot
+	if quantity == 0 || b.Rage.Available > b.Rage.Maximum {
+		b.Rage.Available = b.Rage.Maximum
 	}
 }

--- a/models/class/barbarian_test.go
+++ b/models/class/barbarian_test.go
@@ -215,12 +215,12 @@ func TestBarbarianUseSlots(t *testing.T) {
 			character: &models.Character{},
 			barbarian: &Barbarian{
 				Rage: Rage{
-					Slot:      4,
+					Maximum:   4,
 					Available: 4,
 				},
 			},
 			expected: Rage{
-				Slot:      4,
+				Maximum:   4,
 				Available: 3,
 			},
 		},
@@ -256,12 +256,12 @@ func TestBarbarianRecoverClassSlots(t *testing.T) {
 			character: &models.Character{},
 			barbarian: &Barbarian{
 				Rage: Rage{
-					Slot:      4,
+					Maximum:   4,
 					Available: 2,
 				},
 			},
 			expected: Rage{
-				Slot:      4,
+				Maximum:   4,
 				Available: 3,
 			},
 		},
@@ -271,12 +271,12 @@ func TestBarbarianRecoverClassSlots(t *testing.T) {
 			recover:   0,
 			barbarian: &Barbarian{
 				Rage: Rage{
-					Slot:      4,
+					Maximum:   4,
 					Available: 2,
 				},
 			},
 			expected: Rage{
-				Slot:      4,
+				Maximum:   4,
 				Available: 4,
 			},
 		},

--- a/models/class/bard.go
+++ b/models/class/bard.go
@@ -18,7 +18,7 @@ type Bard struct {
 
 type BardicInspiration struct {
 	Available int `json:"available"`
-	Slot      int `json:"slot"`
+	Maximum   int `json:"maximum"`
 }
 
 func LoadBard(data []byte) (*Bard, error) {
@@ -89,8 +89,8 @@ func (b *Bard) PrintClassDetails(c *models.Character) []string {
 		s = append(s, collegeHeader)
 	}
 
-	if b.BardicInspiration.Available != 0 && b.BardicInspiration.Slot != 0 {
-		bardicSlots := c.GetSlots(b.BardicInspiration.Available, b.BardicInspiration.Slot)
+	if b.BardicInspiration.Available != 0 && b.BardicInspiration.Maximum != 0 {
+		bardicSlots := c.GetSlots(b.BardicInspiration.Available, b.BardicInspiration.Maximum)
 		biLine := fmt.Sprintf("**Bardic Inspiration**: %s\n\n", bardicSlots)
 		s = append(s, biLine)
 	}
@@ -141,7 +141,7 @@ func (b *Bard) RecoverClassTokens(tokenName string, quantity int) {
 	b.BardicInspiration.Available += quantity
 
 	// if no quantity is provided, or the new value exceeds the max we will perform a full recover
-	if quantity == 0 || b.BardicInspiration.Available > b.BardicInspiration.Slot {
-		b.BardicInspiration.Available = b.BardicInspiration.Slot
+	if quantity == 0 || b.BardicInspiration.Available > b.BardicInspiration.Maximum {
+		b.BardicInspiration.Available = b.BardicInspiration.Maximum
 	}
 }

--- a/models/class/bard_test.go
+++ b/models/class/bard_test.go
@@ -218,12 +218,12 @@ func TestBardUseClassSlots(t *testing.T) {
 			character: &models.Character{},
 			bard: &Bard{
 				BardicInspiration: BardicInspiration{
-					Slot:      4,
+					Maximum:   4,
 					Available: 4,
 				},
 			},
 			expected: BardicInspiration{
-				Slot:      4,
+				Maximum:   4,
 				Available: 3,
 			},
 		},
@@ -258,12 +258,12 @@ func TestBardRecoverClassSlots(t *testing.T) {
 			recover:   1,
 			bard: &Bard{
 				BardicInspiration: BardicInspiration{
-					Slot:      4,
+					Maximum:   4,
 					Available: 2,
 				},
 			},
 			expected: BardicInspiration{
-				Slot:      4,
+				Maximum:   4,
 				Available: 3,
 			},
 		},
@@ -273,12 +273,12 @@ func TestBardRecoverClassSlots(t *testing.T) {
 			recover:   0,
 			bard: &Bard{
 				BardicInspiration: BardicInspiration{
-					Slot:      4,
+					Maximum:   4,
 					Available: 2,
 				},
 			},
 			expected: BardicInspiration{
-				Slot:      4,
+				Maximum:   4,
 				Available: 4,
 			},
 		},

--- a/types/spells.go
+++ b/types/spells.go
@@ -2,7 +2,7 @@ package types
 
 type SpellSlot struct {
 	Level     int `json:"level"`
-	Slot      int `json:"slot"`
+	Maximum   int `json:"maximum"`
 	Available int `json:"available"`
 }
 


### PR DESCRIPTION
Rename struct fields/json elements of "slot" to "maximum" for clarity. It was initially written when the only slots I was considering were for spells, but now that we use class tokens and generic character tokens the clarity will be helpful