### PR TITLE
modified rendering of 'not found'

### DIFF
--- a/tui/search/update.go
+++ b/tui/search/update.go
@@ -44,9 +44,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			var result string
 			var err error
 
-			if searchInput == "" {
-				result = "not found"
-			} else {
+			if searchInput != "" {
 				result, err = searchUserInput(searchInput, m.selectedTabIndex, m.viewport.Width)
 			}
 


### PR DESCRIPTION
We return the not found string from the user input when we don't get a successful response. Eventually we'll want to add more context around the error being a 404 vs a 500 if dnd5e server is down or something.