### PR TITLE
fixed panic when trying to recover slots out of range

### DIFF
--- a/character-management/models/character.go
+++ b/character-management/models/character.go
@@ -823,7 +823,10 @@ func (c *Character) UseSpellSlot(level int) {
 func (c *Character) RecoverSpellSlots(level int, quantity int) {
 	for i := range c.SpellSlots {
 		if c.SpellSlots[i].Level == level {
-			if quantity == 0 {
+			if c.SpellSlots[i].Maximum == 0 {
+				logger.Warnf("Slot level '%d' cannot be recovered because the maximum 0", c.SpellSlots[i].Maximum)
+				return
+			} else if quantity == 0 {
 				c.SpellSlots[i].Available = c.SpellSlots[i].Maximum
 				return
 			}


### PR DESCRIPTION
If a user tries to recover slots by quantity for a slot level with a max slot of 0, the program panics. This is a fix and a log for that situation. 

In the future I want all CLI commands to return errors that are handled by in the CLI/TUI callers. 