### PR TITLE
Tui Spell Name Bug Fix

### DIFF
--- a/tui/manage/spells/spells-model.go
+++ b/tui/manage/spells/spells-model.go
@@ -31,8 +31,8 @@ func NewSpellsModel() SpellsModel {
 }
 
 func GetKnownSpellContent(character models.Character, width int) string {
-	width = width - (widthPadding * 2) //padding on both sides
-	longestSpellNameWidth := 0
+	width = width - (widthPadding * 2) // padding on both sides
+	longestSpellNameWidth := 4
 	maxSpellNameWidth := width - 29 // based on width of viewport and characters in header
 
 	spellNames := make(map[string]string)
@@ -71,7 +71,7 @@ func GetKnownSpellContent(character models.Character, width int) string {
 }
 
 func GetSpellSlotContent(character models.Character, width int) string {
-	width = width - (widthPadding * 2) //padding on both sides
+	width = width - (widthPadding * 2) // padding on both sides
 	slotHeader := "Spell Slots"
 	slotContent := fmt.Sprintf("%s\n", slotHeader)
 	slotContent += fmt.Sprintf("%s\n", strings.Repeat("─", width))

--- a/tui/manage/update.go
+++ b/tui/manage/update.go
@@ -29,7 +29,9 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 		innerWidth, availableHeight := m.getInnerDimensions()
 		m.basicInfoTab = m.basicInfoTab.UpdateSize(innerWidth, availableHeight, *m.character)
-		m.spellsTab = m.spellsTab.UpdateSize(innerWidth, availableHeight, *m.character)
+		if m.character.SpellSaveDC > 0 {
+			m.spellsTab = m.spellsTab.UpdateSize(innerWidth, availableHeight, *m.character)
+		}
 		m.equipmentTab = m.equipmentTab.UpdateSize(innerWidth, availableHeight, *m.character)
 		m.classTab = m.classTab.UpdateSize(innerWidth, availableHeight, *m.character)
 		m.notesTab = m.notesTab.UpdateSize(innerWidth, availableHeight, *m.character)


### PR DESCRIPTION
Error: 

Caught panic:

strings: negative Repeat count

Restoring terminal...

goroutine 1 [running]:
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:26 +0x64                                                               runtime/debug.PrintStack()
        /usr/local/go/src/runtime/debug/stack.go:18 +0x1c
github.com/charmbracelet/bubbletea.(*Program).recoverFromPanic(0x140000e37c0, {0x100f02b40, 0x100f89a10})                       /Users/onioncall/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.10/tea.go:847 +0xa0
github.com/charmbracelet/bubbletea.(*Program).Run.func2()
        /Users/onioncall/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.10/tea.go:638 +0xdc                         panic({0x100f02b40?, 0x100f89a10?})
        /usr/local/go/src/runtime/panic.go:787 +0x124
strings.Repeat({0x100ec92e8?, 0x14000338530?}, 0x0?)                                                                            /usr/local/go/src/strings/strings.go:624 +0x588                                                                 github.com/onioncall/dndgo/tui/manage/spells.GetKnownSpellContent({{0x140000a3770, 0xd}, 0x0, {0x140000a3768, 0x5}, 0x0, {0x140000a3780, 0x6}, {0x0, 0x0}, ...}, ...)
        /Users/onioncall/repos/dndgo/tui/manage/spells/spells-model.go:49 +0x1ec                                        github.com/onioncall/dndgo/tui/manage/spells.SpellsModel.UpdateSize({{0x36, 0x1, {{{...}, {...}, 0x0}, {{...}, {...}, 0x0}, {{...}, {...}, ...}, ...}, ...}, ...}, ...)
        /Users/onioncall/repos/dndgo/tui/manage/spells/spells-model.go:130 +0x168
github.com/onioncall/dndgo/tui/manage.Model.Update({0x0, 0x0, 0x0, {0x140000945a0, 0x6, 0x6}, {{0x0, 0x0}, {0x100dfa79f, 0x2}, ...}, ...}, ...)
        /Users/onioncall/repos/dndgo/tui/manage/update.go:32 +0x12ec
github.com/onioncall/dndgo/tui/menu.Model.Update({0x78, 0x21, 0x1, {0x1400015fda0, 0x3, 0x3}, {0x100dfaebe, 0x5}, {0x100dfa8db, 0x3}, ...}, ...)
        /Users/onioncall/repos/dndgo/tui/menu/update.go:19 +0x2a0
github.com/charmbracelet/bubbletea.(*Program).eventLoop(0x140000e37c0, {0x100f8df18?, 0x1400020c008?}, 0x140000961c0)
        /Users/onioncall/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.10/tea.go:494 +0x6c0
github.com/charmbracelet/bubbletea.(*Program).Run(0x140000e37c0)
        /Users/onioncall/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.10/tea.go:716 +0x958
github.com/onioncall/dndgo/cmd.init.func13(0x1400011d300?, {0x100dfac54?, 0x4?, 0x100dfab68?})
        /Users/onioncall/repos/dndgo/cmd/tui.go:18 +0xa8
github.com/spf13/cobra.(*Command).execute(0x101251440, {0x101280fc0, 0x0, 0x0})
        /Users/onioncall/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1019 +0x810
github.com/spf13/cobra.(*Command).ExecuteC(0x101250c00)
        /Users/onioncall/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x350
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/onioncall/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
github.com/onioncall/dndgo/cmd.Execute(...)
        /Users/onioncall/repos/dndgo/cmd/root.go:42
main.main()
        /Users/onioncall/repos/dndgo/main.go:15 +0x7c
Application had an unrecoverable error: program was killed: program experienced a panic
exit status 1

Wasn't accounting for the length of 'name' when using the repeater, changed the default max line length from 0 to 4 to account for those characters