### PR TITLE
Moved Skill Proficiency Bonus

### DIFF
--- a/character-management/models/character.go
+++ b/character-management/models/character.go
@@ -76,6 +76,10 @@ func (c *Character) calculateSkillModifierFromBase() {
 		for _, a := range c.Abilities {
 			if strings.ToLower(skill.Ability) == strings.ToLower(a.Name) {
 				c.Skills[i].SkillModifier = a.AbilityModifier
+
+				if skill.Proficient {
+					c.Skills[i].SkillModifier += c.Proficiency
+				}
 			}
 		}
 	}
@@ -463,10 +467,6 @@ func (c *Character) BuildSkills() []string {
 	s = append(s, skillSpacer)
 
 	for _, skill := range c.Skills {
-		if skill.Proficient {
-			skill.SkillModifier += c.Proficiency
-		}
-
 		skillModifierString := ""
 		if skill.SkillModifier > 0 {
 			skillModifierString = "+"


### PR DESCRIPTION
The calculation for adding the proficiency bonus to a skill mod when that skill is proficient used to be in the markdown, since we didn't have a reason to calculate it ahead of time before we added the TUI. 

I moved this into the calculate step so it can be shared by both the CLI and TUI.